### PR TITLE
Wait after initial reset until device is ready

### DIFF
--- a/adafruit_mma8451.py
+++ b/adafruit_mma8451.py
@@ -127,8 +127,12 @@ class MMA8451:
             raise RuntimeError("Failed to find MMA8451, check wiring!")
         # Reset and wait for chip to be ready.
         self._write_u8(_MMA8451_REG_CTRL_REG2, 0x40)
-        while self._read_u8(_MMA8451_REG_CTRL_REG2) & 0x40 > 0:
-            pass
+        while True:
+            try:
+                if not self._read_u8(_MMA8451_REG_CTRL_REG2) & 0x40 > 0:
+                    break # Continue if chip is ready
+            except OSError as e: # Ignore OSError. After reset the device may fail to respond
+                pass
         # Enable 4G range.
         self._write_u8(_MMA8451_REG_XYZ_DATA_CFG, RANGE_4G)
         # High resolution mode.

--- a/adafruit_mma8451.py
+++ b/adafruit_mma8451.py
@@ -130,8 +130,10 @@ class MMA8451:
         while True:
             try:
                 if not self._read_u8(_MMA8451_REG_CTRL_REG2) & 0x40 > 0:
-                    break # Continue if chip is ready
-            except OSError as e: # Ignore OSError. After reset the device may fail to respond
+                    # Continue if chip is ready
+                    break
+            # Ignore OSError. After reset the device may fail to respond
+            except OSError:
                 pass
         # Enable 4G range.
         self._write_u8(_MMA8451_REG_XYZ_DATA_CFG, RANGE_4G)


### PR DESCRIPTION
Regarding issue #27 after the initial reset the device may fail to respond immediately to the next access if there is no delay to allow the chip to start back up.
This raises an uncaught exception instead of properly waiting.

This PR retries the first access after the reset by catching the OSError after the reset until it succeeds to let the chip start back up properly.

If the device is actually not connected the initial poll will still fail properly and raise an exception.